### PR TITLE
Fix calendar event bold text styling

### DIFF
--- a/app/components/calendar/CalendarDay.tsx
+++ b/app/components/calendar/CalendarDay.tsx
@@ -52,7 +52,6 @@ export default function CalendarDay({ day, onSelect, onEventClick }: CalendarDay
           <EventIndicator
             key={`${event.id}-${index}`}
             event={event}
-            isFirst={index === 0}
             onClick={onEventClick}
           />
         ))}

--- a/app/components/calendar/EventIndicator.tsx
+++ b/app/components/calendar/EventIndicator.tsx
@@ -6,11 +6,10 @@ import { truncateEventSummary } from '@/lib/calendar/utils';
 
 interface EventIndicatorProps {
   event: CalendarEvent;
-  isFirst?: boolean;
   onClick?: (event: CalendarEvent) => void;
 }
 
-export default function EventIndicator({ event, isFirst = false, onClick }: EventIndicatorProps) {
+export default function EventIndicator({ event, onClick }: EventIndicatorProps) {
   const truncatedSummary = truncateEventSummary(event.summary, 15);
   
   const handleClick = (e: React.MouseEvent) => {
@@ -24,7 +23,7 @@ export default function EventIndicator({ event, isFirst = false, onClick }: Even
         bg-[#cc785c] text-[#000000] text-xs px-2 py-1 rounded
         truncate w-full text-center cursor-pointer
         hover:bg-[#b56a4f] transition-colors
-        ${isFirst ? 'font-medium' : 'opacity-90'}
+        font-medium
       `}
       title={event.summary}
       onClick={handleClick}


### PR DESCRIPTION
- Remove conditional bold styling that only applied to first event
- All events now have consistent font-medium (bold) styling
- Remove unused isFirst prop from EventIndicator component
- Update CalendarDay to not pass isFirst prop

Fixes issue where second and subsequent events on same day were not bold like the first event.