### PR TITLE
feat: show event names on current day and closest event day

### DIFF
--- a/app/components/calendar/CalendarContainer.tsx
+++ b/app/components/calendar/CalendarContainer.tsx
@@ -133,6 +133,7 @@ export default function CalendarContainer({ className = '' }: CalendarContainerP
         onSelectDate={handleSelectDate}
         onEventClick={handleEventClick}
         isLoading={calendarState.isLoading}
+        allEvents={events}
       />
       
       <CalendarActions

--- a/app/components/calendar/CalendarDay.tsx
+++ b/app/components/calendar/CalendarDay.tsx
@@ -2,21 +2,26 @@
 
 import React from 'react';
 import { CalendarDay as CalendarDayType, CalendarEvent } from '@/types/calendar';
-import { truncateEventSummary } from '@/lib/calendar/utils';
+import { truncateEventSummary, isCurrentDayOrClosestEventDay } from '@/lib/calendar/utils';
 import EventIndicator from './EventIndicator';
 
 interface CalendarDayProps {
   day: CalendarDayType;
   onSelect: () => void;
   onEventClick?: (event: CalendarEvent) => void;
+  allEvents?: CalendarEvent[]; // All events in the calendar to find closest event
 }
 
-export default function CalendarDay({ day, onSelect, onEventClick }: CalendarDayProps) {
+export default function CalendarDay({ day, onSelect, onEventClick, allEvents = [] }: CalendarDayProps) {
   const dayNumber = day.date.getDate();
   const isCurrentMonth = day.isCurrentMonth;
   const isToday = day.isToday;
   const isSelected = day.isSelected;
   const hasEvents = day.hasEvents;
+  
+  // Check if this day should show event name instead of Claude logo
+  // Only show event name if: has events AND is in current month AND (is today OR is closest event day)
+  const shouldShowEventName = hasEvents && isCurrentMonth && isCurrentDayOrClosestEventDay(day.date, allEvents);
 
   const handleDayClick = () => {
     if (hasEvents && day.events.length > 0 && onEventClick) {
@@ -65,21 +70,27 @@ export default function CalendarDay({ day, onSelect, onEventClick }: CalendarDay
         </div>
       )}
 
-      {/* Centered Claude icon for days with events */}
+      {/* Event content - show event name for current day or closest event day, Claude icon otherwise */}
       {hasEvents && (
-        <div className="absolute inset-0 flex items-center justify-center">
-          <svg 
-            fill="white" 
-            fillRule="evenodd" 
-            height="24" 
-            width="24" 
-            viewBox="0 0 24 24" 
-            xmlns="http://www.w3.org/2000/svg"
-            className="w-6 h-6"
-          >
-            <title>Claude</title>
-            <path d="M4.709 15.955l4.72-2.647.08-.23-.08-.128H9.2l-.79-.048-2.698-.073-2.339-.097-2.266-.122-.571-.121L0 11.784l.055-.352.48-.321.686.06 1.52.103 2.278.158 1.652.097 2.449.255h.389l.055-.157-.134-.098-.103-.097-2.358-1.596-2.552-1.688-1.336-.972-.724-.491-.364-.462-.158-1.008.656-.722.881.06.225.061.893.686 1.908 1.476 2.491 1.833.365.304.145-.103.019-.073-.164-.274-1.355-2.446-1.446-2.49-.644-1.032-.17-.619a2.97 2.97 0 01-.104-.729L6.283.134 6.696 0l.996.134.42.364.62 1.414 1.002 2.229 1.555 3.03.456.898.243.832.091.255h.158V9.01l.128-1.706.237-2.095.23-2.695.08-.76.376-.91.747-.492.584.28.48.685-.067.444-.286 1.851-.559 2.903-.364 1.942h.212l.243-.242.985-1.306 1.652-2.064.73-.82.85-.904.547-.431h1.033l.76 1.129-.34 1.166-1.064 1.347-.881 1.142-1.264 1.7-.79 1.36.073.11.188-.02 2.856-.606 1.543-.28 1.841-.315.833.388.091.395-.328.807-1.969.486-2.309.462-3.439.813-.042.03.049.061 1.549.146.662.036h1.622l3.02.225.79.522.474.638-.079.485-1.215.62-1.64-.389-3.829-.91-1.312-.329h-.182v.11l1.093 1.068 2.006 1.81 2.509 2.33.127.578-.322.455-.34-.049-2.205-1.657-.851-.747-1.926-1.62h-.128v.17l.444.649 2.345 3.521.122 1.08-.17.353-.608.213-.668-.122-1.374-1.925-1.415-2.167-1.143-1.943-.14.08-.674 7.254-.316.37-.729.28-.607-.461-.322-.747.322-1.476.389-1.924.315-1.53.286-1.9.17-.632-.012-.042-.14.018-1.434 1.967-2.18 2.945-1.726 1.845-.414.164-.717-.37.067-.662.401-.589 2.388-3.036 1.44-1.882.93-1.086-.006-.158h-.055L4.132 18.56l-1.13.146-.487-.456.061-.746.231-.243 1.908-1.312-.006.006z"></path>
-          </svg>
+        <div className="absolute inset-0 flex items-center justify-center px-1">
+          {shouldShowEventName ? (
+            <div className="text-white text-[10px] font-medium text-center leading-tight max-w-full overflow-hidden">
+              {truncateEventSummary(day.events[0].summary, 30)}
+            </div>
+          ) : (
+            <svg 
+              fill="white" 
+              fillRule="evenodd" 
+              height="24" 
+              width="24" 
+              viewBox="0 0 24 24" 
+              xmlns="http://www.w3.org/2000/svg"
+              className="w-6 h-6"
+            >
+              <title>Claude</title>
+              <path d="M4.709 15.955l4.72-2.647.08-.23-.08-.128H9.2l-.79-.048-2.698-.073-2.339-.097-2.266-.122-.571-.121L0 11.784l.055-.352.48-.321.686.06 1.52.103 2.278.158 1.652.097 2.449.255h.389l.055-.157-.134-.098-.103-.097-2.358-1.596-2.552-1.688-1.336-.972-.724-.491-.364-.462-.158-1.008.656-.722.881.06.225.061.893.686 1.908 1.476 2.491 1.833.365.304.145-.103.019-.073-.164-.274-1.355-2.446-1.446-2.49-.644-1.032-.17-.619a2.97 2.97 0 01-.104-.729L6.283.134 6.696 0l.996.134.42.364.62 1.414 1.002 2.229 1.555 3.03.456.898.243.832.091.255h.158V9.01l.128-1.706.237-2.095.23-2.695.08-.76.376-.91.747-.492.584.28.48.685-.067.444-.286 1.851-.559 2.903-.364 1.942h.212l.243-.242.985-1.306 1.652-2.064.73-.82.85-.904.547-.431h1.033l.76 1.129-.34 1.166-1.064 1.347-.881 1.142-1.264 1.7-.79 1.36.073.11.188-.02 2.856-.606 1.543-.28 1.841-.315.833.388.091.395-.328.807-1.969.486-2.309.462-3.439.813-.042.03.049.061 1.549.146.662.036h1.622l3.02.225.79.522.474.638-.079.485-1.215.62-1.64-.389-3.829-.91-1.312-.329h-.182v.11l1.093 1.068 2.006 1.81 2.509 2.33.127.578-.322.455-.34-.049-2.205-1.657-.851-.747-1.926-1.62h-.128v.17l.444.649 2.345 3.521.122 1.08-.17.353-.608.213-.668-.122-1.374-1.925-1.415-2.167-1.143-1.943-.14.08-.674 7.254-.316.37-.729.28-.607-.461-.322-.747.322-1.476.389-1.924.315-1.53.286-1.9.17-.632-.012-.042-.14.018-1.434 1.967-2.18 2.945-1.726 1.845-.414.164-.717-.37.067-.662.401-.589 2.388-3.036 1.44-1.882.93-1.086-.006-.158h-.055L4.132 18.56l-1.13.146-.487-.456.061-.746.231-.243 1.908-1.312-.006.006z"></path>
+            </svg>
+          )}
         </div>
       )}
 

--- a/app/components/calendar/CalendarGrid.tsx
+++ b/app/components/calendar/CalendarGrid.tsx
@@ -10,6 +10,7 @@ interface CalendarGridProps {
   onSelectDate: (date: Date) => void;
   onEventClick?: (event: CalendarEvent) => void;
   isLoading?: boolean;
+  allEvents?: CalendarEvent[]; // All events to pass to CalendarDay components
 }
 
 export default function CalendarGrid({
@@ -17,6 +18,7 @@ export default function CalendarGrid({
   onSelectDate,
   onEventClick,
   isLoading = false,
+  allEvents = [],
 }: CalendarGridProps) {
   const dayNames = getDayNames(true);
 
@@ -70,6 +72,7 @@ export default function CalendarGrid({
             day={day}
             onSelect={() => onSelectDate(day.date)}
             onEventClick={onEventClick}
+            allEvents={allEvents}
           />
         ))}
       </div>

--- a/lib/calendar/utils.ts
+++ b/lib/calendar/utils.ts
@@ -246,6 +246,58 @@ export function generateCalendarSubscriptionUrl(calendarId: string): string {
 }
 
 /**
+ * Find the closest event to the current date
+ */
+export function findClosestEvent(events: CalendarEvent[], referenceDate: Date = new Date()): CalendarEvent | null {
+  if (events.length === 0) return null;
+
+  let closestEvent: CalendarEvent | null = null;
+  let closestDistance = Infinity;
+
+  for (const event of events) {
+    const eventDate = event.start.dateTime 
+      ? new Date(event.start.dateTime)
+      : new Date(event.start.date!);
+    
+    // Calculate days difference (absolute value)
+    const timeDifference = Math.abs(eventDate.getTime() - referenceDate.getTime());
+    const daysDifference = timeDifference / (1000 * 60 * 60 * 24);
+
+    if (daysDifference < closestDistance) {
+      closestDistance = daysDifference;
+      closestEvent = event;
+    }
+  }
+
+  return closestEvent;
+}
+
+/**
+ * Check if a date matches the current day or the day of the closest event
+ */
+export function isCurrentDayOrClosestEventDay(date: Date, events: CalendarEvent[]): boolean {
+  const today = new Date();
+  
+  // Check if it's today
+  if (isToday(date)) {
+    return true;
+  }
+
+  // Find the closest event
+  const closestEvent = findClosestEvent(events, today);
+  if (!closestEvent) {
+    return false;
+  }
+
+  // Check if the date matches the closest event's date
+  const closestEventDate = closestEvent.start.dateTime 
+    ? new Date(closestEvent.start.dateTime)
+    : new Date(closestEvent.start.date!);
+
+  return isSameDay(date, closestEventDate);
+}
+
+/**
  * Generate "Add to Calendar" URL for Google Calendar
  */
 export function generateAddToCalendarUrl(event: CalendarEvent): string {


### PR DESCRIPTION
- Add utility functions to find closest event to current date
- Modify CalendarDay to show event names instead of Claude logo for:
  - Current day (if it has events and is in current month)
  - Day with closest event to today (if in current month)
- Update CalendarGrid and CalendarContainer to pass event data
- Reduce event text size to text-[10px] for better fit
- Ensure proper centering for both event text and Claude logos
- Maintain Claude logo display for all other event days