### PR TITLE
style: update mobile menu items to use theme-text-primary color

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -235,7 +235,7 @@ export default function Header() {
                 <motion.div variants={mobileItemVariants}>
                   <Link
                     href="/about"
-                    className={`flex px-3 py-4 text-[var(--theme-button-text)] hover:text-[var(--theme-text-accent)] hover:bg-[var(--theme-button-bg)]/10 transition-all duration-200 font-medium font-sans rounded-lg min-h-[48px] items-center touch-manipulation`}
+                    className={`flex px-3 py-4 text-[var(--theme-text-primary)] hover:text-[var(--theme-text-accent)] hover:bg-white/10 transition-all duration-200 font-medium font-sans rounded-lg min-h-[48px] items-center touch-manipulation`}
                     onClick={() => setIsMobileMenuOpen(false)}
                   >
                     About
@@ -244,7 +244,7 @@ export default function Header() {
                 <motion.div variants={mobileItemVariants}>
                   <Link
                     href="/team"
-                    className={`flex px-3 py-4 text-[var(--theme-button-text)] hover:text-[var(--theme-text-accent)] hover:bg-[var(--theme-button-bg)]/10 transition-all duration-200 font-medium font-sans rounded-lg min-h-[48px] items-center touch-manipulation`}
+                    className={`flex px-3 py-4 text-[var(--theme-text-primary)] hover:text-[var(--theme-text-accent)] hover:bg-white/10 transition-all duration-200 font-medium font-sans rounded-lg min-h-[48px] items-center touch-manipulation`}
                     onClick={() => setIsMobileMenuOpen(false)}
                   >
                     Team
@@ -253,7 +253,7 @@ export default function Header() {
                 <motion.div variants={mobileItemVariants}>
                   <Link
                     href="/careers"
-                    className={`flex px-3 py-4 text-[var(--theme-button-text)] hover:text-[var(--theme-text-accent)] hover:bg-[var(--theme-button-bg)]/10 transition-all duration-200 font-medium font-sans rounded-lg min-h-[48px] items-center touch-manipulation`}
+                    className={`flex px-3 py-4 text-[var(--theme-text-primary)] hover:text-[var(--theme-text-accent)] hover:bg-white/10 transition-all duration-200 font-medium font-sans rounded-lg min-h-[48px] items-center touch-manipulation`}
                     onClick={() => setIsMobileMenuOpen(false)}
                   >
                     Careers


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switch mobile menu item text to `var(--theme-text-primary)` and hover background to `white/10` for About, Team, and Careers links.
> 
> - **UI Styling**:
>   - In `app/components/Header.tsx` mobile menu:
>     - Update `About`, `Team`, `Careers` links to use `text-[var(--theme-text-primary)]`.
>     - Change hover background from `var(--theme-button-bg)/10` to `white/10`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 984dbb2a4523c5f9e2759bef217c5281e73920a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->