### PR TITLE
Added isAsuStudent field to Hackathon Signup Form

### DIFF
--- a/app/api/hackathon/route.ts
+++ b/app/api/hackathon/route.ts
@@ -28,6 +28,7 @@ export async function POST(request: NextRequest) {
 
     // Extract form data
     const track = formData.get("track") as string;
+    const isAsuStudent = formData.get("isAsuStudent") === "true";
     const isAsuOnlineStudent = formData.get("isAsuOnlineStudent") === "true";
     const firstName = formData.get("firstName") as string;
     const lastName = formData.get("lastName") as string;
@@ -42,8 +43,6 @@ export async function POST(request: NextRequest) {
     // Validate required fields
     if (
       !track ||
-      isAsuOnlineStudent === undefined ||
-      isAsuOnlineStudent === null ||
       !firstName ||
       !lastName ||
       !schoolEmail ||
@@ -76,7 +75,8 @@ export async function POST(request: NextRequest) {
                 { name: "School Email", value: schoolEmail },
                 { name: "Year", value: year, inline: true },
                 { name: "Track", value: track, inline: true },
-                { name: "ASU Online Student", value: isAsuOnlineStudent ? "Yes" : "No" },
+                { name: "ASU Student", value: isAsuStudent ? "Yes" : "No", inline: true },
+                { name: "ASU Online Student", value: isAsuOnlineStudent ? "Yes" : "No", inline: true },
                 { name: "Hackathons Participated", value: hackathonsParticipated, inline: true },
                 { name: "Experience Level", value: experienceLevel, inline: true },
               ],
@@ -99,6 +99,7 @@ Personal Information:
 - School Email: ${schoolEmail}
 - Year: ${year}
 - Track: ${track}
+- ASU Student: ${isAsuStudent ? "Yes" : "No"}
 - ASU Online Student: ${isAsuOnlineStudent ? "Yes" : "No"}
 - Hackathons Participated: ${hackathonsParticipated}
 - Experience Level: ${experienceLevel}
@@ -126,6 +127,7 @@ Registration submitted on: ${new Date().toLocaleString()}
       console.log("Attempting to save to Google Sheets...");
       const sheetsData = {
         track,
+        isAsuStudent,
         isAsuOnlineStudent,
         firstName,
         lastName,


### PR DESCRIPTION
## Changes

- **Hackathon Form**: Added `isAsuStudent` field to capture ASU student
- **API Integration**: 
  - Updated Discord webhook payload to include `isAsuStudent` field
  - Updated Google Apps Script mapping to handle `isAsuStudent` field
- **Form Validation**: Removed unnecessary validation for `isAsuOnlineStudent` since a default "No" selection is provided

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `isAsuStudent`, gates `isAsuOnlineStudent` on it, and updates API, Discord/email payloads, and Sheets mapping with minor UI/validation/analytics tweaks.
> 
> - **Frontend (Hackathon form `app/components/HackathonSignupForm.tsx`)**:
>   - Add `isAsuStudent` field and UI (ButtonGroup); conditionally show `isAsuOnlineStudent` only when ASU student.
>   - On submit, send `isAsuStudent` and `isAsuOnlineStudent` (online forced false when not ASU).
>   - Remove validation for `isAsuOnlineStudent`; adjust email placeholder based on ASU status; reset defaults after submit.
>   - Update analytics events for ASU affiliation and online status.
> - **Backend (API `app/api/hackathon/route.ts`)**:
>   - Parse `isAsuStudent`; include in Discord embed, email content, and Google Sheets payload.
>   - Simplify required field checks (no `isAsuOnlineStudent` presence check).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b136dc347b746f4e1a10ce96fefec4ce850a596b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->