### PR TITLE
move JoinCard under hero text

### DIFF
--- a/app/components/JoinCard.tsx
+++ b/app/components/JoinCard.tsx
@@ -142,17 +142,17 @@ export default function JoinCard({
 
         <motion.div
           variants={itemVariants}
-          className="grid grid-cols-1 sm:grid-cols-2 gap-2 sm:gap-3"
+          className="flex flex-col sm:flex-row gap-3"
         >
           <Link
             href={discordHref}
             target="_blank"
             rel="noopener noreferrer"
-            className="w-full"
+            className="flex-1"
             data-umami-event="Join Discord"
             data-umami-event-location="JoinCard"
           >
-            <Button variant="primary" size="md" fullWidth>
+            <Button variant="primary" size="md" fullWidth className="whitespace-nowrap">
               Join our Discord
             </Button>
           </Link>
@@ -160,11 +160,11 @@ export default function JoinCard({
             href={benefitsHref}
             target="_blank"
             rel="noopener noreferrer"
-            className="w-full"
+            className="flex-1"
             data-umami-event="Sign Up Benefits"
             data-umami-event-location="JoinCard"
           >
-            <Button variant="secondary" size="md" fullWidth>
+            <Button variant="secondary" size="md" fullWidth className="h-full">
               Sign up to receive benefits
             </Button>
           </Link>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -77,19 +77,34 @@ export default function Home() {
         animate="visible"
         className="font-sans flex-1 pt-4 px-4 pb-0 sm:pt-8 sm:px-8 md:p-20 relative z-10"
       >
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6 md:gap-8 min-h-full items-start max-w-7xl mx-auto">
-          {/* Left half - Title + Hackathon */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 lg:gap-8 items-start max-w-7xl mx-auto">
+          {/* Left half - Title + Hackathon + Join Card */}
           <motion.div
             variants={leftColumnVariants}
-            className="flex flex-col justify-start items-center lg:items-start p-4 gap-4 sm:p-6 sm:gap-6 text-center lg:text-left"
+            className="flex flex-col justify-start items-center lg:items-start gap-6 text-center lg:text-left w-full max-w-2xl"
           >
-            <motion.div variants={itemVariants} className="space-y-3 sm:space-y-4">
-              <Heading level="h1" animate={false} className="leading-tight">
+            <motion.div variants={itemVariants} className="space-y-3 sm:space-y-4 lg:space-y-3 w-full lg:mb-13">
+              <Heading
+                level="h1"
+                animate={false}
+                className="leading-tight text-balance lg:text-5xl xl:text-[3.25rem] 2xl:text-[3.5rem]"
+              >
                 The Arizona State University Claude Builder Club
               </Heading>
-              <Heading level="h3" className="leading-relaxed">
+              <Heading
+                level="h3"
+                className="leading-relaxed text-balance lg:text-2xl xl:text-2xl"
+              >
                 Where curiosity meets <span className="text-[var(--theme-text-accent)] font-bold underline">cutting-edge AI</span>. Build <span className="text-[var(--theme-text-accent)] font-bold underline">anything</span>. Create the <span className="text-[var(--theme-text-accent)] font-bold underline italic">impossible</span>.
               </Heading>
+            </motion.div>
+
+            {/* Join Card moved here */}
+            <motion.div variants={itemVariants} className="w-full">
+              <JoinCard
+                discordHref="https://discord.gg/PRh8F2XebB"
+                benefitsHref="https://docs.google.com/forms/d/e/1FAIpQLScP9LuFwiHEx806tv9zczjCIEzqO1Zjb-FjB4XWoa6BS1NNKQ/viewform"
+              />
             </motion.div>
 
             {/* Hackathon promo */}
@@ -100,20 +115,13 @@ export default function Home() {
             )}
           </motion.div>
 
-          {/* Right half - Calendar + Join Card */}
+          {/* Right half - Calendar only */}
           <motion.div
             variants={rightColumnVariants}
-            className="flex flex-col items-center pt-0 pb-4 px-4 sm:pb-8 md:pb-12 lg:pb-20 lg:px-0"
+            className="flex flex-col items-center lg:items-start w-full max-w-2xl"
           >
-            <motion.div variants={itemVariants} className="w-full max-w-2xl">
-              <CalendarContainer className="w-full max-w-2xl" />
-            </motion.div>
-            {/* Join Card moved here */}
-            <motion.div variants={itemVariants} className="w-full max-w-2xl mt-4">
-              <JoinCard
-                discordHref="https://discord.gg/PRh8F2XebB"
-                benefitsHref="https://docs.google.com/forms/d/e/1FAIpQLScP9LuFwiHEx806tv9zczjCIEzqO1Zjb-FjB4XWoa6BS1NNKQ/viewform"
-              />
+            <motion.div variants={itemVariants} className="w-full">
+              <CalendarContainer className="w-full" />
             </motion.div>
           </motion.div>
         </div>


### PR DESCRIPTION
This pull request updates the layout and styling of the homepage and the `JoinCard` component to improve visual hierarchy and responsiveness. The most significant change is moving the `JoinCard` from the right column to the left, directly under the main heading, and updating its layout for better alignment on different screen sizes.

**Homepage layout improvements:**

* Moved the `JoinCard` component from the right column to the left column, placing it below the main heading and above the hackathon promo for better visibility and flow. The right column now only contains the calendar. (`app/page.tsx`, [[1]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L80-R109) [[2]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L103-R124)
* Adjusted grid and spacing classes on the homepage to improve consistency and alignment across screen sizes. (`app/page.tsx`, [app/page.tsxL80-R109](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L80-R109))

**JoinCard styling enhancements:**

* Changed the layout of the `JoinCard` from a grid to a flexbox for better responsiveness, and updated button container classes for more consistent sizing and alignment. (`app/components/JoinCard.tsx`, [app/components/JoinCard.tsxL145-R167](diffhunk://#diff-1e445de95ebc7dbe39f1e1aefb114356eaa1a7a3c38b0a176c567dc8689ea278L145-R167))
* Added utility classes to the `Button` components within `JoinCard` to prevent text wrapping and ensure consistent button heights. (`app/components/JoinCard.tsx`, [app/components/JoinCard.tsxL145-R167](diffhunk://#diff-1e445de95ebc7dbe39f1e1aefb114356eaa1a7a3c38b0a176c567dc8689ea278L145-R167))