### PR TITLE
Implement Industry page and contact form with email notification

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,0 +1,204 @@
+import { NextRequest, NextResponse } from "next/server";
+import nodemailer from "nodemailer";
+
+// Validate required SMTP environment variables
+const requiredEnvVars = ["SMTP_HOST", "SMTP_PORT", "SMTP_USER", "SMTP_PASS"];
+
+const validateEnv = () => {
+  for (const key of requiredEnvVars) {
+    if (!process.env[key]) {
+      throw new Error(`Missing SMTP configuration: ${key}`);
+    }
+  }
+};
+
+// Create nodemailer transporter
+const createTransporter = () => {
+  validateEnv();
+
+  return nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port: parseInt(process.env.SMTP_PORT || "587", 10),
+    secure: process.env.SMTP_SECURE === "true",
+    auth: {
+      user: process.env.SMTP_USER,
+      pass: process.env.SMTP_PASS,
+    },
+  });
+};
+
+// Sanitize form inputs
+const sanitize = (value: FormDataEntryValue | null): string =>
+  typeof value === "string" ? value.trim() : "";
+
+// Send Discord webhook notification
+const sendDiscordNotification = async (submission: {
+  name: string;
+  email: string;
+  company: string;
+  subject: string;
+  message: string;
+  submittedAt: string;
+}) => {
+  const webhookUrl = process.env.CONTACT_DISCORD_WEBHOOK_URL;
+
+  if (!webhookUrl) {
+    console.log("Discord webhook not configured, skipping notification");
+    return;
+  }
+
+  // Truncate message if too long for Discord embed
+  const truncate = (text: string, max = 1800) =>
+    text.length > max ? `${text.slice(0, max - 1)}…` : text;
+
+  try {
+    await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        content: "📬 New Industry Contact Inquiry",
+        embeds: [
+          {
+            title: submission.subject || "Industry Partnership Inquiry",
+            color: 16749901, // #ff914d in decimal (matches accent color)
+            description: truncate(submission.message || "No message provided."),
+            fields: [
+              { name: "Name", value: submission.name, inline: true },
+              { name: "Email", value: submission.email, inline: true },
+              {
+                name: "Company",
+                value: submission.company || "N/A",
+                inline: true,
+              },
+            ],
+            timestamp: submission.submittedAt,
+            thumbnail: {
+              url: "https://asucbc.vercel.app/staff/claude.svg",
+            },
+            footer: {
+              text: "ASU Claude Builder Club - Contact Form",
+            },
+          },
+        ],
+      }),
+    });
+    console.log("Discord notification sent successfully");
+  } catch (error) {
+    console.error("Discord webhook error:", error);
+    // Don't fail the request if Discord webhook fails
+  }
+};
+
+export async function POST(request: NextRequest) {
+  try {
+    const formData = await request.formData();
+
+    // Extract and sanitize form fields
+    const name = sanitize(formData.get("name"));
+    const email = sanitize(formData.get("email"));
+    const company = sanitize(formData.get("company"));
+    const subject = sanitize(formData.get("subject"));
+    const message = sanitize(formData.get("message"));
+
+    // Validate required fields
+    if (!name || !email || !subject || !message) {
+      return NextResponse.json(
+        { error: "All required fields must be filled" },
+        { status: 400 }
+      );
+    }
+
+    // Validate email format
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      return NextResponse.json(
+        { error: "Please enter a valid email address" },
+        { status: 400 }
+      );
+    }
+
+    const submittedAt = new Date().toISOString();
+
+    const submission = {
+      name,
+      email,
+      company,
+      subject,
+      message,
+      submittedAt,
+    };
+
+    // Send email via SMTP
+    const transporter = createTransporter();
+
+    const mailOptions = {
+      from: process.env.SMTP_USER,
+      to: process.env.RECIPIENT_EMAIL || process.env.SMTP_USER,
+      replyTo: email,
+      subject: `[Industry Inquiry] ${subject}`,
+      text: `
+New Industry Contact Form Submission
+
+Contact Information:
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Name:        ${name}
+Email:       ${email}
+Company:     ${company || "Not provided"}
+
+Subject:
+${subject}
+
+Message:
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+${message}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Submitted at: ${new Date(submittedAt).toLocaleString()}
+      `.trim(),
+    };
+
+    await transporter.sendMail(mailOptions);
+    console.log("Email sent successfully to:", mailOptions.to);
+
+    // Send Discord notification (non-blocking)
+    await sendDiscordNotification(submission);
+
+    return NextResponse.json(
+      { message: "Message sent successfully" },
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error("Contact form error:", error);
+
+    // Provide helpful error message for SMTP configuration issues
+    if (
+      error instanceof Error &&
+      error.message.toLowerCase().includes("missing smtp configuration")
+    ) {
+      return NextResponse.json(
+        {
+          error:
+            "Email service is not configured. Please contact the administrator.",
+        },
+        { status: 503 }
+      );
+    }
+
+    return NextResponse.json(
+      { error: "Failed to send message. Please try again later." },
+      { status: 500 }
+    );
+  }
+}
+
+// Handle CORS preflight requests
+export async function OPTIONS() {
+  return new NextResponse(null, {
+    status: 200,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "POST, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
+    },
+  });
+}

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -152,9 +152,43 @@ export default function Header() {
                 </motion.div>
               </motion.div>
 
+              <motion.div
+                custom={3}
+                initial="hidden"
+                animate="visible"
+                variants={navItemVariants}
+              >
+                <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
+                  <Link
+                    href="/industry"
+                    className={`relative z-10 text-[var(--theme-text-primary)] hover:text-[var(--theme-text-accent)] transition-all duration-200 font-medium font-sans px-4 py-3 rounded-md hover:bg-white/10 min-h-[48px] flex items-center touch-manipulation`}
+                    data-umami-event="Nav - Industry"
+                  >
+                    Industry
+                  </Link>
+                </motion.div>
+              </motion.div>
+
+              <motion.div
+                custom={4}
+                initial="hidden"
+                animate="visible"
+                variants={navItemVariants}
+              >
+                <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
+                  <Link
+                    href="/contact"
+                    className={`relative z-10 text-[var(--theme-text-primary)] hover:text-[var(--theme-text-accent)] transition-all duration-200 font-medium font-sans px-4 py-3 rounded-md hover:bg-white/10 min-h-[48px] flex items-center touch-manipulation`}
+                    data-umami-event="Nav - Contact"
+                  >
+                    Contact
+                  </Link>
+                </motion.div>
+              </motion.div>
+
               {showHackathonPromo && (
                 <motion.div
-                  custom={3}
+                  custom={5}
                   initial="hidden"
                   animate="visible"
                   variants={navItemVariants}
@@ -173,7 +207,7 @@ export default function Header() {
               )}
 
               <motion.div
-                custom={4}
+                custom={6}
                 initial="hidden"
                 animate="visible"
                 variants={navItemVariants}
@@ -272,6 +306,26 @@ export default function Header() {
                     data-umami-event="Mobile Nav - Careers"
                   >
                     Careers
+                  </Link>
+                </motion.div>
+                <motion.div variants={mobileItemVariants}>
+                  <Link
+                    href="/industry"
+                    className={`flex px-3 py-4 text-[var(--theme-text-primary)] hover:text-[var(--theme-text-accent)] hover:bg-[var(--theme-text-accent)]/10 transition-all duration-200 font-medium font-sans rounded-lg min-h-[48px] items-center touch-manipulation`}
+                    onClick={() => setIsMobileMenuOpen(false)}
+                    data-umami-event="Mobile Nav - Industry"
+                  >
+                    Industry
+                  </Link>
+                </motion.div>
+                <motion.div variants={mobileItemVariants}>
+                  <Link
+                    href="/contact"
+                    className={`flex px-3 py-4 text-[var(--theme-text-primary)] hover:text-[var(--theme-text-accent)] hover:bg-[var(--theme-text-accent)]/10 transition-all duration-200 font-medium font-sans rounded-lg min-h-[48px] items-center touch-manipulation`}
+                    onClick={() => setIsMobileMenuOpen(false)}
+                    data-umami-event="Mobile Nav - Contact"
+                  >
+                    Contact
                   </Link>
                 </motion.div>
                 {showHackathonPromo && (

--- a/app/components/ui/Typography.tsx
+++ b/app/components/ui/Typography.tsx
@@ -136,7 +136,7 @@ export const Label = forwardRef<HTMLLabelElement, LabelProps>(
         ref={ref}
         whileHover={{ x: 2 }}
         transition={{ type: "spring", stiffness: 300, damping: 20 }}
-        className={`text-sm font-medium text-[var(--theme-text-primary)] inline-block mb-1 ${className}`}
+        className={`text-sm font-medium text-[var(--theme-text-primary)] flex items-center mb-1 ${className}`}
         {...props}
       >
         {children}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,400 @@
+"use client";
+
+import { useState } from "react";
+import { motion } from "framer-motion";
+import { FiMail, FiUser, FiBriefcase, FiMessageSquare, FiSend, FiAlertCircle, FiClock, FiCheck } from "react-icons/fi";
+import Header from "../components/Header";
+import Footer from "../components/Footer";
+import {
+  Heading,
+  Text,
+  Label,
+  Input,
+  Textarea,
+  Button,
+  Card,
+} from "../components/ui";
+
+interface ContactFormData {
+  name: string;
+  email: string;
+  company: string;
+  subject: string;
+  message: string;
+}
+
+interface ContactFormErrors {
+  name?: string;
+  email?: string;
+  subject?: string;
+  message?: string;
+}
+
+const initialFormData: ContactFormData = {
+  name: "",
+  email: "",
+  company: "",
+  subject: "",
+  message: "",
+};
+
+export default function ContactPage() {
+  const [formData, setFormData] = useState<ContactFormData>(initialFormData);
+  const [errors, setErrors] = useState<ContactFormErrors>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitStatus, setSubmitStatus] = useState<"idle" | "success" | "error">("idle");
+
+  const validateForm = (): boolean => {
+    const newErrors: ContactFormErrors = {};
+
+    if (!formData.name.trim()) {
+      newErrors.name = "Name is required";
+    }
+
+    const trimmedEmail = formData.email.trim();
+    if (!trimmedEmail) {
+      newErrors.email = "Email is required";
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmedEmail)) {
+      newErrors.email = "Please enter a valid email address";
+    }
+
+    if (!formData.subject.trim()) {
+      newErrors.subject = "Subject is required";
+    }
+
+    if (!formData.message.trim()) {
+      newErrors.message = "Message is required";
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+
+    if (errors[name as keyof ContactFormErrors]) {
+      setErrors((prev) => ({ ...prev, [name]: undefined }));
+    }
+  };
+
+  const resetForm = () => {
+    setFormData(initialFormData);
+    setErrors({});
+    setSubmitStatus("idle");
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+
+    if (!validateForm()) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setSubmitStatus("idle");
+
+    try {
+      const body = new FormData();
+      body.append("name", formData.name.trim());
+      body.append("email", formData.email.trim());
+      body.append("company", formData.company.trim());
+      body.append("subject", formData.subject.trim());
+      body.append("message", formData.message.trim());
+
+      const response = await fetch("/api/contact", {
+        method: "POST",
+        body,
+      });
+
+      if (response.ok) {
+        setSubmitStatus("success");
+
+        if (typeof window !== "undefined" && (window as any).umami) {
+          (window as any).umami.track("Contact Form Submitted", {
+            hasCompany: !!formData.company.trim(),
+          });
+        }
+
+        setFormData(initialFormData);
+      } else {
+        setSubmitStatus("error");
+
+        if (typeof window !== "undefined" && (window as any).umami) {
+          (window as any).umami.track("Contact Form Error", {
+            status: response.status,
+          });
+        }
+      }
+    } catch (error) {
+      console.error("Contact form submission failed:", error);
+      setSubmitStatus("error");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-[100dvh] max-h-[100dvh] relative overflow-y-auto">
+      <Header />
+
+      <div className="font-sans relative">
+        {/* Hero Section - VISIBLE IMMEDIATELY */}
+        <section className="relative px-8 pt-20 pb-16 sm:px-20 sm:pt-32">
+          <div className="absolute inset-0 bg-gradient-to-br from-[var(--theme-text-accent)]/5 via-transparent to-[var(--theme-text-accent)]/10 pointer-events-none" />
+
+          <div className="max-w-5xl mx-auto relative z-10">
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6 }}
+              className="text-center space-y-6 mb-16"
+            >
+              <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-[var(--theme-text-accent)]/10 border border-[var(--theme-text-accent)]/20">
+                <FiClock className="w-4 h-4 text-[var(--theme-text-accent)]" />
+                <Text size="sm" className="font-medium text-[var(--theme-text-accent)]">
+                  We respond within 48 hours
+                </Text>
+              </div>
+
+              <Heading level="h1" animate={false} className="text-5xl sm:text-6xl lg:text-7xl">
+                Let's Build{" "}
+                <span className="text-[var(--theme-text-accent)]">Together</span>
+              </Heading>
+
+              <Text size="xl" variant="secondary" className="max-w-2xl mx-auto leading-relaxed">
+                Ready to partner with ASU's top AI engineering talent? Share your project vision and let's create something exceptional.
+              </Text>
+            </motion.div>
+
+            {/* Success State */}
+            {submitStatus === "success" && (
+              <motion.div
+                initial={{ opacity: 0, scale: 0.9 }}
+                animate={{ opacity: 1, scale: 1 }}
+                transition={{ type: "spring", stiffness: 200, damping: 20 }}
+                className="mb-12"
+              >
+                <Card gradient className="p-12 text-center relative overflow-hidden">
+                  <div className="absolute inset-0 bg-gradient-to-br from-green-500/10 to-transparent pointer-events-none" />
+                  <div className="relative z-10 space-y-6">
+                    <motion.div
+                      initial={{ scale: 0 }}
+                      animate={{ scale: 1 }}
+                      transition={{ type: "spring", stiffness: 200, delay: 0.2 }}
+                      className="w-20 h-20 mx-auto rounded-full bg-green-500/20 flex items-center justify-center"
+                    >
+                      <FiCheck className="w-10 h-10 text-green-500" />
+                    </motion.div>
+                    <Heading level="h3" animate={false} className="text-3xl">
+                      Message Sent Successfully!
+                    </Heading>
+                    <Text variant="secondary" size="lg">
+                      Thank you for reaching out. We'll get back to you within 48 hours.
+                    </Text>
+                    <Button type="button" variant="secondary" size="lg" onClick={resetForm}>
+                      Send Another Message
+                    </Button>
+                  </div>
+                </Card>
+              </motion.div>
+            )}
+
+            {/* Error State */}
+            {submitStatus === "error" && (
+              <motion.div
+                initial={{ opacity: 0, y: -10 }}
+                animate={{ opacity: 1, y: 0 }}
+                className="mb-8 p-6 rounded-2xl border border-red-500/40 bg-red-500/10"
+              >
+                <div className="flex items-start gap-4">
+                  <FiAlertCircle className="w-6 h-6 text-red-400 flex-shrink-0 mt-0.5" />
+                  <div className="flex-1">
+                    <Text className="font-semibold text-red-200 mb-2">
+                      Unable to send message
+                    </Text>
+                    <Text size="sm" className="text-red-300">
+                      Please check your connection and try again, or email us directly at{" "}
+                      <a
+                        href="mailto:shivenshekar01@gmail.com"
+                        className="underline font-semibold hover:text-red-100"
+                      >
+                        shivenshekar01@gmail.com
+                      </a>
+                    </Text>
+                  </div>
+                </div>
+              </motion.div>
+            )}
+
+            {/* Contact Form - VISIBLE IMMEDIATELY */}
+            {submitStatus !== "success" && (
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.4, duration: 0.6 }}
+              >
+                <Card gradient className="p-8 sm:p-12">
+                  <form onSubmit={handleSubmit} className="space-y-8">
+                    <div className="grid sm:grid-cols-2 gap-6">
+                      {/* Name Field */}
+                      <div>
+                        <Label htmlFor="name" required className="flex items-center gap-2 mb-3">
+                          <FiUser className="w-4 h-4" />
+                          Full Name
+                        </Label>
+                        <Input
+                          id="name"
+                          name="name"
+                          type="text"
+                          value={formData.name}
+                          onChange={handleChange}
+                          placeholder="John Doe"
+                          error={errors.name}
+                          fullWidth
+                          autoFocus
+                        />
+                      </div>
+
+                      {/* Email Field */}
+                      <div>
+                        <Label htmlFor="email" required className="flex items-center gap-2 mb-3">
+                          <FiMail className="w-4 h-4" />
+                          Email Address
+                        </Label>
+                        <Input
+                          type="email"
+                          id="email"
+                          name="email"
+                          value={formData.email}
+                          onChange={handleChange}
+                          placeholder="john@company.com"
+                          error={errors.email}
+                          fullWidth
+                        />
+                      </div>
+                    </div>
+
+                    <div className="grid sm:grid-cols-2 gap-6">
+                      {/* Company Field */}
+                      <div>
+                        <Label htmlFor="company" className="flex items-center gap-2 mb-3">
+                          <FiBriefcase className="w-4 h-4" />
+                          Company
+                        </Label>
+                        <Input
+                          id="company"
+                          name="company"
+                          type="text"
+                          value={formData.company}
+                          onChange={handleChange}
+                          placeholder="Your company name"
+                          fullWidth
+                        />
+                      </div>
+
+                      {/* Subject Field */}
+                      <div>
+                        <Label htmlFor="subject" required className="flex items-center gap-2 mb-3">
+                          <FiMessageSquare className="w-4 h-4" />
+                          Subject
+                        </Label>
+                        <Input
+                          id="subject"
+                          name="subject"
+                          type="text"
+                          value={formData.subject}
+                          onChange={handleChange}
+                          placeholder="Partnership inquiry"
+                          error={errors.subject}
+                          fullWidth
+                        />
+                      </div>
+                    </div>
+
+                    {/* Message Field */}
+                    <div>
+                      <Label htmlFor="message" required className="flex items-center gap-2 mb-3">
+                        <FiMessageSquare className="w-4 h-4" />
+                        Message
+                      </Label>
+                      <Textarea
+                        id="message"
+                        name="message"
+                        value={formData.message}
+                        onChange={handleChange}
+                        rows={8}
+                        placeholder="Tell us about your project goals, timelines, technical requirements, and what success looks like for you..."
+                        error={errors.message}
+                        fullWidth
+                      />
+                    </div>
+
+                    {/* Submit Section */}
+                    <div className="flex flex-col sm:flex-row gap-4 sm:items-center sm:justify-between pt-6 border-t border-[var(--theme-card-border)]">
+                      <Text size="sm" variant="secondary" className="flex items-center gap-2">
+                        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+                        </svg>
+                        Secure & confidential
+                      </Text>
+
+                      <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
+                        <Button
+                          type="submit"
+                          variant="primary"
+                          size="lg"
+                          disabled={isSubmitting}
+                          className="min-w-[200px]"
+                        >
+                          {isSubmitting ? (
+                            <span className="flex items-center gap-2">
+                              <svg
+                                className="animate-spin h-5 w-5"
+                                xmlns="http://www.w3.org/2000/svg"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                              >
+                                <circle
+                                  className="opacity-25"
+                                  cx="12"
+                                  cy="12"
+                                  r="10"
+                                  stroke="currentColor"
+                                  strokeWidth="4"
+                                ></circle>
+                                <path
+                                  className="opacity-75"
+                                  fill="currentColor"
+                                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                                ></path>
+                              </svg>
+                              Sending...
+                            </span>
+                          ) : (
+                            <span className="flex items-center gap-2">
+                              <FiSend />
+                              Send Message
+                            </span>
+                          )}
+                        </Button>
+                      </motion.div>
+                    </div>
+                  </form>
+                </Card>
+              </motion.div>
+            )}
+          </div>
+        </section>
+
+        {/* Footer */}
+        <div className="px-8 pb-20 sm:px-20">
+          <div className="max-w-7xl mx-auto">
+            <Footer />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/industry/page.tsx
+++ b/app/industry/page.tsx
@@ -1,0 +1,282 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { motion, AnimatePresence } from "framer-motion";
+import Tilt from "react-parallax-tilt";
+import { FiMail, FiChevronDown } from "react-icons/fi";
+import Header from "../components/Header";
+import Footer from "../components/Footer";
+import { Heading, Text, Card } from "../components/ui";
+
+// Data
+const currentSponsor = {
+  name: "Anthropic",
+  description: "Anthropic partners with us to bridge industry and academia, empowering ASU students to build real-world AI solutions with Claude. Together we're fostering the next generation of responsible AI developers.",
+  logo: "/assets/hackathon/sponsors/anthropic.png",
+  url: "https://www.anthropic.com",
+};
+
+const pastSponsors = [
+  { name: "Polymarket", logo: "/assets/hackathon/sponsors/polymarket.svg", url: "https://polymarket.com" },
+  { name: "ether.fi", logo: "/assets/hackathon/sponsors/etherfi.png", url: "https://www.ether.fi" },
+  { name: "Base", logo: "/assets/hackathon/sponsors/base.svg", url: "https://www.base.org" },
+  { name: "Redbull", logo: "/assets/hackathon/sponsors/redbull.png", url: "https://www.redbull.com" },
+  { name: "Acorns", logo: "/assets/hackathon/sponsors/acorns.svg", url: "https://www.acorns.com" },
+  { name: "Streetsmart", logo: "/assets/hackathon/sponsors/streetsmart.svg", url: "https://streetsmart.org" },
+];
+
+const faqData = [
+  {
+    question: "How is ASU Claude Builder Club structured?",
+    answer: "Each semester, we partner with clients to build custom products and services tailored to their needs. We assign dedicated project leaders and developers who work directly with companies to implement a fully-fledged project. Every team will meet weekly and check in throughout the semester.",
+  },
+  {
+    question: "What is the timeframe for an ASU Claude Builder Club project?",
+    answer: "Projects run over 10-12 weeks. We kick off in week 1 after a pitch call and a formal statement of work, demo progress around week 5, and present the final product with documentation and support by the semester's end.",
+  },
+  {
+    question: "What value does ASU Claude Builder Club provide?",
+    answer: "You get a high-impact solution built by top ASU talent, increased campus visibility, and a chance to support a student organization developing future tech leaders.",
+  },
+];
+
+// FAQ Accordion Component
+function FAQAccordion() {
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+
+  return (
+    <div className="space-y-4">
+      {faqData.map((faq, index) => (
+        <motion.div
+          key={index}
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ delay: index * 0.1 }}
+        >
+          <Card
+            className="overflow-hidden cursor-pointer hover:border-[var(--theme-text-accent)] transition-colors"
+            onClick={() => setOpenIndex(openIndex === index ? null : index)}
+          >
+            <div className="p-6">
+              <div className="flex items-center justify-between gap-4">
+                <Heading level="h3" animate={false} className="text-lg font-semibold text-[var(--theme-text-accent)]">
+                  {faq.question}
+                </Heading>
+                <motion.div
+                  animate={{ rotate: openIndex === index ? 180 : 0 }}
+                  transition={{ duration: 0.3 }}
+                >
+                  <FiChevronDown className="w-5 h-5 flex-shrink-0" />
+                </motion.div>
+              </div>
+
+              <AnimatePresence>
+                {openIndex === index && (
+                  <motion.div
+                    initial={{ height: 0, opacity: 0 }}
+                    animate={{ height: "auto", opacity: 1 }}
+                    exit={{ height: 0, opacity: 0 }}
+                    transition={{ duration: 0.3 }}
+                  >
+                    <Text variant="secondary" className="mt-4 leading-relaxed">
+                      {faq.answer}
+                    </Text>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            </div>
+          </Card>
+        </motion.div>
+      ))}
+    </div>
+  );
+}
+
+export default function IndustryPage() {
+  return (
+    <div className="min-h-[100dvh] max-h-[100dvh] relative overflow-y-auto">
+      <Header />
+
+      <div className="font-sans relative">
+        {/* Hero Section */}
+        <section className="relative px-8 pt-20 pb-32 sm:px-20 sm:pt-32 sm:pb-40">
+          <div className="absolute inset-0 bg-gradient-to-br from-[var(--theme-text-accent)]/5 via-transparent to-[var(--theme-text-accent)]/10 pointer-events-none" />
+
+          <div className="max-w-7xl mx-auto relative z-10">
+            <div className="grid lg:grid-cols-2 gap-16 items-center">
+              {/* Left: Hero Content */}
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6 }}
+                className="space-y-8"
+              >
+                <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-[var(--theme-text-accent)]/10 border border-[var(--theme-text-accent)]/20">
+                  <div className="w-2 h-2 rounded-full bg-[var(--theme-text-accent)] animate-pulse" />
+                  <Text size="sm" className="font-medium text-[var(--theme-text-accent)]">
+                    Now Accepting Partnership Proposals
+                  </Text>
+                </div>
+
+                <Heading level="h1" animate={false} className="text-5xl sm:text-6xl lg:text-7xl leading-tight">
+                  Partner With{" "}
+                  <span className="text-[var(--theme-text-accent)]">ASU's AI Innovators</span>
+                </Heading>
+
+                <Text size="xl" variant="secondary" className="leading-relaxed">
+                  Join leading companies partnering with elite ASU engineering talent to build cutting-edge AI solutions with Claude.
+                </Text>
+
+                <Link href="/contact">
+                  <motion.button
+                    whileHover={{ scale: 1.05 }}
+                    whileTap={{ scale: 0.95 }}
+                    className="px-8 py-4 bg-[var(--theme-button-bg)] text-white rounded-xl font-semibold flex items-center gap-2 shadow-lg"
+                  >
+                    <FiMail />
+                    Get in Touch
+                  </motion.button>
+                </Link>
+              </motion.div>
+
+              {/* Right: Current Sponsor */}
+              <motion.div
+                initial={{ opacity: 0, x: 20 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ duration: 0.6, delay: 0.2 }}
+              >
+                <Tilt
+                  tiltMaxAngleX={8}
+                  tiltMaxAngleY={8}
+                  scale={1.02}
+                  glareEnable
+                  glareMaxOpacity={0.2}
+                >
+                  <Link href={currentSponsor.url} target="_blank" rel="noopener noreferrer" className="block">
+                    <Card gradient hoverable animated={false} className="p-8 sm:p-12">
+                      <Text size="sm" className="uppercase tracking-[0.3em] text-[var(--theme-text-accent)] mb-6 font-bold">
+                        CURRENT SPONSOR
+                      </Text>
+                      <div className="relative h-20 w-56">
+                        <Image
+                          src={currentSponsor.logo}
+                          alt={`${currentSponsor.name} logo`}
+                          fill
+                          sizes="224px"
+                          className="object-contain dark:invert dark:hue-rotate-180"
+                        />
+                      </div>
+                      <Text variant="secondary" className="leading-relaxed">
+                        {currentSponsor.description}
+                      </Text>
+                    </Card>
+                  </Link>
+                </Tilt>
+              </motion.div>
+            </div>
+          </div>
+        </section>
+
+        {/* FAQ Section */}
+        <section className="px-8 py-20 sm:px-20 bg-[var(--theme-card-bg)]/30">
+          <div className="max-w-4xl mx-auto">
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              className="text-center mb-12"
+            >
+              <Text size="sm" className="uppercase tracking-[0.3em] text-[var(--theme-text-accent)] mb-4 font-bold">
+                PARTNERSHIP FAQ
+              </Text>
+              <Heading level="h2" animate={false} className="text-4xl sm:text-5xl">
+                Frequently Asked Questions
+              </Heading>
+            </motion.div>
+            <FAQAccordion />
+          </div>
+        </section>
+
+        {/* Past Sponsors */}
+        <section className="px-8 py-20 sm:px-20">
+          <div className="max-w-7xl mx-auto">
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              className="text-center mb-12"
+            >
+              <Text size="sm" className="uppercase tracking-[0.3em] text-[var(--theme-text-accent)] mb-4 font-bold">
+                TRUSTED BY
+              </Text>
+              <Heading level="h2" animate={false} className="text-3xl sm:text-4xl">
+                Past Sponsors
+              </Heading>
+            </motion.div>
+            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-6">
+              {pastSponsors.map((sponsor, index) => (
+                <motion.div
+                  key={sponsor.name}
+                  initial={{ opacity: 0, scale: 0.8 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  transition={{ delay: 0.2 + index * 0.05 }}
+                >
+                  <Tilt
+                    tiltMaxAngleX={5}
+                    tiltMaxAngleY={5}
+                    scale={1.05}
+                    glareEnable
+                    glareMaxOpacity={0.1}
+                  >
+                    <Link href={sponsor.url} target="_blank" rel="noopener noreferrer">
+                      <Card hoverable animated={false} className="p-6 flex items-center justify-center">
+                        <div className="relative h-12 w-28">
+                          <Image
+                            src={sponsor.logo}
+                            alt={`${sponsor.name} logo`}
+                            fill
+                            sizes="112px"
+                            className="object-contain dark:invert dark:hue-rotate-180"
+                          />
+                        </div>
+                      </Card>
+                    </Link>
+                  </Tilt>
+                </motion.div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Footer */}
+        <div className="px-8 pb-20 sm:px-20">
+          <div className="max-w-7xl mx-auto">
+            <Footer />
+          </div>
+        </div>
+      </div>
+
+      {/* Floating Contact Button */}
+      <motion.div
+        initial={{ opacity: 0, scale: 0.5 }}
+        animate={{ opacity: 1, scale: 1 }}
+        transition={{ delay: 1, type: "spring", stiffness: 200 }}
+        className="fixed bottom-6 left-6 z-50"
+      >
+        <Link href="/contact">
+          <motion.button
+            whileHover={{ scale: 1.1, rotate: 5 }}
+            whileTap={{ scale: 0.9 }}
+            className="w-14 h-14 sm:w-16 sm:h-16 rounded-full bg-[var(--theme-button-bg)] text-white shadow-2xl flex items-center justify-center border-2 border-[var(--theme-text-accent)]/30"
+            aria-label="Contact Us"
+          >
+            <FiMail className="w-6 h-6" />
+          </motion.button>
+        </Link>
+      </motion.div>
+    </div>
+  );
+}


### PR DESCRIPTION
Hey! This PR adds the industry sponsor page and contact form we needed.

Fixes #45 

## What I built

Created `/industry` page with:
- Current sponsor card for Anthropic
- Grid of past sponsors (Polymarket, ether.fi, Base, Redbull, Acorns, Streetsmart)
- Floating contact button that sticks to bottom left

Created `/contact` page with a form that sends emails via SMTP. (Also notification using Discord Webhook)

Added both links to the header nav.

---
Built using Claude