### PR TITLE
Add case competition toggle to hackathon2 signup

### DIFF
--- a/app/api/hackathon2/route.ts
+++ b/app/api/hackathon2/route.ts
@@ -34,24 +34,42 @@ export async function POST(request: NextRequest) {
     const lookingForTeam = formData.get("lookingForTeam") === "true";
     const major = formData.get("major") as string;
     const github = formData.get("github") as string;
+    const linkedin = formData.get("linkedin") as string;
+    const registrationType = (formData.get("registrationType") as string) || "hackathon";
+    const isCaseCompetition = registrationType === "caseCompetition";
 
     // Validate required fields
-    if (
-      !firstName ||
-      !lastName ||
-      !email ||
-      !year ||
-      !major ||
-      !github
-    ) {
+    if (!firstName || !lastName || !email || !year || !major) {
       return NextResponse.json(
         { error: "Missing required fields" },
         { status: 400 }
       );
     }
 
+    if (!isCaseCompetition && !github) {
+      return NextResponse.json(
+        { error: "GitHub username is required for hackathon registration" },
+        { status: 400 }
+      );
+    }
+
+    const registrationLabel = isCaseCompetition ? "Case Competition" : "Hackathon 2";
+
     const hookURL = process.env.DISCORD_HACKATHON2_WEBHOOK_URL;
     if (hookURL) {
+      const discordFields = [
+        { name: "Registration Type", value: registrationLabel, inline: true },
+        { name: "First Name", value: firstName, inline: true },
+        { name: "Last Name", value: lastName, inline: true },
+        { name: "Email", value: email },
+        { name: "Year", value: year, inline: true },
+        { name: "Major", value: major, inline: true },
+        ...(isCaseCompetition
+          ? (linkedin ? [{ name: "LinkedIn", value: linkedin, inline: true }] : [])
+          : [{ name: "GitHub", value: github, inline: true }]),
+        { name: "Looking for Team", value: lookingForTeam ? "Yes" : "No", inline: true },
+      ];
+
       // Send data to Discord webhook
       await fetch(hookURL, {
         method: "POST",
@@ -59,20 +77,12 @@ export async function POST(request: NextRequest) {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          content: "New Hackathon 2 Signup",
+          content: `New ${registrationLabel} Signup`,
           embeds: [
             {
-              title: "New Hackathon 2 Registration Received",
-              color: 16763802,
-              fields: [
-                { name: "First Name", value: firstName, inline: true },
-                { name: "Last Name", value: lastName, inline: true },
-                { name: "Email", value: email },
-                { name: "Year", value: year, inline: true },
-                { name: "Major", value: major, inline: true },
-                { name: "GitHub", value: github, inline: true },
-                { name: "Looking for Team", value: lookingForTeam ? "Yes" : "No", inline: true },
-              ],
+              title: `New ${registrationLabel} Registration Received`,
+              color: isCaseCompetition ? 3447003 : 16763802,
+              fields: discordFields,
               timestamp: new Date().toISOString(),
               thumbnail: { url: "https://asucbc.vercel.app/staff/claude.svg" },
             },
@@ -84,7 +94,7 @@ export async function POST(request: NextRequest) {
 
     // Create email content
     const emailContent = `
-New Hackathon 2 Registration Received
+New ${registrationLabel} Registration Received
 
 Personal Information:
 - First Name: ${firstName}
@@ -92,7 +102,9 @@ Personal Information:
 - Email: ${email}
 - Year: ${year}
 - Major: ${major}
-- GitHub: ${github}
+${isCaseCompetition
+  ? `- LinkedIn: ${linkedin || "Not provided"}`
+  : `- GitHub: ${github}`}
 - Looking for Team: ${lookingForTeam ? "Yes" : "No"}
 
 Registration submitted on: ${new Date().toLocaleString()}
@@ -104,13 +116,15 @@ Registration submitted on: ${new Date().toLocaleString()}
     if (process.env.GOOGLE_APPS_SCRIPT_URL_HACKATHON2) {
       console.log("Attempting to save to Google Sheets...");
       const sheetsData = {
+        registrationType: registrationLabel,
         firstName,
         lastName,
         email,
         year,
         lookingForTeam,
         major,
-        github,
+        github: github || "",
+        linkedin: linkedin || "",
       };
 
       try {
@@ -154,7 +168,9 @@ Registration submitted on: ${new Date().toLocaleString()}
       const mailOptions = {
         from: process.env.SMTP_USER,
         to: process.env.RECIPIENT_EMAIL || "shivenshekar01@gmail.com",
-        subject: `🚀 New Hackathon 2 Registration: ${firstName} ${lastName}`,
+        subject: isCaseCompetition
+          ? `🏆 New Case Competition Registration: ${firstName} ${lastName}`
+          : `🚀 New Hackathon 2 Registration: ${firstName} ${lastName}`,
         text: emailContent,
       };
 
@@ -164,7 +180,7 @@ Registration submitted on: ${new Date().toLocaleString()}
     }
 
     return NextResponse.json(
-      { message: "Hackathon 2 registration submitted successfully" },
+      { message: `${registrationLabel} registration submitted successfully` },
       { status: 200 }
     );
   } catch (error) {

--- a/app/components/Hackathon2SignupForm.tsx
+++ b/app/components/Hackathon2SignupForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Heading, Text, Label, Input, Button, ButtonGroup } from "./ui";
+import { Heading, Text, Label, Input, Button, ButtonGroup, Toggle } from "./ui";
 import HackathonCongratulations from "./HackathonCongratulations";
 import Link from "next/link";
 
@@ -13,6 +13,8 @@ interface FormData {
   lookingForTeam: boolean;
   major: string;
   github: string;
+  linkedin: string;
+  registrationType: "hackathon" | "caseCompetition";
 }
 
 interface FormErrors {
@@ -22,6 +24,7 @@ interface FormErrors {
   year?: string;
   major?: string;
   github?: string;
+  linkedin?: string;
 }
 
 export default function Hackathon2SignupForm() {
@@ -33,6 +36,8 @@ export default function Hackathon2SignupForm() {
     lookingForTeam: false,
     major: '',
     github: '',
+    linkedin: '',
+    registrationType: "hackathon",
   });
 
   const [errors, setErrors] = useState<FormErrors>({});
@@ -40,6 +45,7 @@ export default function Hackathon2SignupForm() {
   const [submitStatus, setSubmitStatus] = useState<
     "idle" | "success" | "error"
   >("idle");
+  const [successType, setSuccessType] = useState<"hackathon" | "caseCompetition">("hackathon");
 
   // Function to reset form and go back to registration
   const handleReset = () => {
@@ -52,6 +58,8 @@ export default function Hackathon2SignupForm() {
       lookingForTeam: false,
       major: '',
       github: '',
+      linkedin: '',
+      registrationType: "hackathon",
     });
   };
 
@@ -80,7 +88,7 @@ export default function Hackathon2SignupForm() {
       newErrors.major = "Major is required";
     }
 
-    if (!formData.github.trim()) {
+    if (formData.registrationType === "hackathon" && !formData.github.trim()) {
       newErrors.github = "GitHub username is required";
     }
 
@@ -118,6 +126,8 @@ export default function Hackathon2SignupForm() {
       formDataToSend.append('lookingForTeam', String(formData.lookingForTeam));
       formDataToSend.append('major', formData.major);
       formDataToSend.append('github', formData.github);
+      formDataToSend.append('linkedin', formData.linkedin);
+      formDataToSend.append('registrationType', formData.registrationType);
       formDataToSend.append('hackathonId', 'hackathon2');
 
       const response = await fetch('/api/hackathon2', {
@@ -126,12 +136,14 @@ export default function Hackathon2SignupForm() {
       });
 
       if (response.ok) {
+        setSuccessType(formData.registrationType);
         setSubmitStatus("success");
         // Track successful submission
         if (typeof window !== 'undefined' && (window as any).umami) {
           (window as any).umami.track('Hackathon2 Form Submitted', {
             year: formData.year,
-            lookingForTeam: formData.lookingForTeam
+            lookingForTeam: formData.lookingForTeam,
+            registrationType: formData.registrationType,
           });
         }
         setFormData({
@@ -142,6 +154,8 @@ export default function Hackathon2SignupForm() {
           lookingForTeam: false,
           major: '',
           github: '',
+          linkedin: '',
+          registrationType: "hackathon",
         });
       } else {
         setSubmitStatus("error");
@@ -160,14 +174,16 @@ export default function Hackathon2SignupForm() {
 
   // Show congratulations screen on success
   if (submitStatus === "success") {
-    return <HackathonCongratulations onReset={handleReset} hackathonName="Claude Builder Club Hackathon 2026" eventDates="March 20-22, 2026" />;
+    return <HackathonCongratulations onReset={handleReset} hackathonName={successType === "caseCompetition" ? "Claude Builder Club Case Competition 2026" : "Claude Builder Club Hackathon 2026"} eventDates="March 20-22, 2026" />;
   }
 
   return (
     <div className="max-w-2xl mx-auto pt-8 sm:pt-12 md:pt-16">
       <div className="mb-8">
         <Heading level="h2" animate={false} className="mb-4">
-          Hackathon Registration Form
+          {formData.registrationType === "caseCompetition"
+            ? "Case Competition Registration Form"
+            : "Hackathon Registration Form"}
         </Heading>
         <Text size="sm" variant="secondary">
           All fields marked with * are required.
@@ -177,6 +193,25 @@ export default function Hackathon2SignupForm() {
         <div className="mt-4 p-4 bg-[var(--theme-text-accent)]/10 rounded-lg border-l-4 border-[var(--theme-text-accent)]">
           <Text size="sm" className="font-semibold text-[var(--theme-text-primary)]">
             <span className="text-[var(--theme-text-accent)]">⚠️ Important:</span> If you're registered on SDC (Sun Devil Connect), you must also register here to confirm your attendance.
+          </Text>
+        </div>
+
+        {/* Registration Type Toggle */}
+        <div
+          className="mt-4 flex items-center gap-3 cursor-pointer"
+          onClick={() => {
+            const next = formData.registrationType === "caseCompetition" ? "hackathon" : "caseCompetition";
+            setFormData((prev) => ({ ...prev, registrationType: next }));
+            setErrors((prev) => ({ ...prev, github: undefined, linkedin: undefined }));
+          }}
+        >
+          <Toggle
+            checked={formData.registrationType === "caseCompetition"}
+            onChange={() => {}}
+          />
+          <Text size="sm" variant="secondary" className="flex-1">
+            <span className="font-bold text-[var(--theme-text-primary)]">Switch to Case Competition Registration</span>{" "}
+            <span className="text-[var(--theme-text-accent)]">(winner may be interviewed by sponsor)</span>
           </Text>
         </div>
       </div>
@@ -333,25 +368,45 @@ export default function Hackathon2SignupForm() {
           />
         </div>
 
-        {/* GitHub */}
-        <div>
-          <Label htmlFor="github" required>
-            GitHub Username
-          </Label>
-          <Input
-            type="text"
-            id="github"
-            name="github"
-            value={formData.github}
-            onChange={handleInputChange}
-            error={errors.github}
-            placeholder="your-github-username"
-            fullWidth
-          />
-          <Text size="xs" variant="secondary" className="mt-1">
-            We'll use this to verify your project submissions
-          </Text>
-        </div>
+        {/* GitHub (hackathon) or LinkedIn (case competition) */}
+        {formData.registrationType === "hackathon" ? (
+          <div>
+            <Label htmlFor="github" required>
+              GitHub Username
+            </Label>
+            <Input
+              type="text"
+              id="github"
+              name="github"
+              value={formData.github}
+              onChange={handleInputChange}
+              error={errors.github}
+              placeholder="your-github-username"
+              fullWidth
+            />
+            <Text size="xs" variant="secondary" className="mt-1">
+              We'll use this to verify your project submissions
+            </Text>
+          </div>
+        ) : (
+          <div>
+            <Label htmlFor="linkedin">
+              LinkedIn Profile URL
+            </Label>
+            <Input
+              type="text"
+              id="linkedin"
+              name="linkedin"
+              value={formData.linkedin}
+              onChange={handleInputChange}
+              placeholder="https://linkedin.com/in/your-profile"
+              fullWidth
+            />
+            <Text size="xs" variant="secondary" className="mt-1">
+              Optional — helps sponsors connect with you
+            </Text>
+          </div>
+        )}
 
         {/* Submit Button */}
         <div className="pt-6">
@@ -388,7 +443,9 @@ export default function Hackathon2SignupForm() {
                 Submitting...
               </span>
             ) : (
-              "Submit Registration"
+              formData.registrationType === "caseCompetition"
+                ? "Submit Case Competition Registration"
+                : "Submit Registration"
             )}
           </Button>
         </div>

--- a/app/components/ui/Toggle.tsx
+++ b/app/components/ui/Toggle.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { forwardRef } from "react";
+
+export interface ToggleProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+const Toggle = forwardRef<HTMLButtonElement, ToggleProps>(
+  ({ checked, onChange, disabled = false, className = "" }, ref) => {
+    return (
+      <button
+        ref={ref}
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        disabled={disabled}
+        onClick={() => !disabled && onChange(!checked)}
+        className={`
+          relative inline-flex items-center shrink-0
+          w-12 h-6 rounded-sm cursor-pointer
+          transition-colors duration-200
+          disabled:opacity-50 disabled:cursor-not-allowed
+          ${
+            checked
+              ? "bg-[var(--theme-text-accent)]"
+              : "bg-[var(--theme-card-border)]"
+          }
+          ${className}
+        `}
+      >
+        <motion.div
+          className="w-5 h-5 rounded-sm bg-white shadow-sm"
+          animate={{
+            x: checked ? 26 : 2,
+          }}
+          transition={{
+            type: "spring",
+            stiffness: 500,
+            damping: 25,
+          }}
+        />
+      </button>
+    );
+  }
+);
+
+Toggle.displayName = "Toggle";
+
+export default Toggle;

--- a/app/components/ui/index.ts
+++ b/app/components/ui/index.ts
@@ -12,6 +12,9 @@ export { Heading, Text, Label } from "./Typography";
 export { default as Input } from "./Input";
 export type { InputProps } from "./Input";
 
+export { default as Toggle } from "./Toggle";
+export type { ToggleProps } from "./Toggle";
+
 export { default as Textarea } from "./Textarea";
 export type { TextareaProps } from "./Textarea";
 


### PR DESCRIPTION
Allow users to switch between hackathon and case competition registration via a toggle. Case comp mode swaps the required GitHub field for an optional LinkedIn field and adjusts the API route, Discord webhook, Google Sheets data, and fallback email to reflect the registration type.