### PR TITLE
Fix calendar re-render issue

### DIFF
--- a/app/components/calendar/CalendarContainer.tsx
+++ b/app/components/calendar/CalendarContainer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { CalendarState, CalendarEvent } from '@/types/calendar';
 import { createCalendarMonth } from '@/lib/calendar/utils';
 import { getEventsForMonth } from '@/lib/calendar/google';
@@ -111,23 +111,22 @@ export default function CalendarContainer({ className = '' }: CalendarContainerP
     }
   };
 
-  const handleSelectDate = (date: Date) => {
+  const handleSelectDate = useCallback((date: Date) => {
     setCalendarState(prev => ({ ...prev, selectedDate: date }));
-  };
+  }, []);
 
-  const handleEventClick = (event: CalendarEvent) => {
+  const handleEventClick = useCallback((event: CalendarEvent) => {
     setSelectedEvent(event);
     setIsModalOpen(true);
-    // Track event click
     if (typeof window !== 'undefined' && (window as any).umami) {
       (window as any).umami.track('Calendar Event Click', { eventName: event.summary });
     }
-  };
+  }, []);
 
-  const handleCloseModal = () => {
+  const handleCloseModal = useCallback(() => {
     setIsModalOpen(false);
     setSelectedEvent(null);
-  };
+  }, []);
 
   const navigation = {
     goToPreviousMonth: handlePreviousMonth,

--- a/app/components/calendar/CalendarDay.tsx
+++ b/app/components/calendar/CalendarDay.tsx
@@ -1,31 +1,36 @@
 'use client';
 
-import React from 'react';
+import { memo, useCallback } from 'react';
 import { CalendarDay as CalendarDayType, CalendarEvent } from '@/types/calendar';
 import { truncateEventSummary } from '@/lib/calendar/utils';
 
 interface CalendarDayProps {
   day: CalendarDayType;
-  onSelect: () => void;
+  onSelectDate: (date: Date) => void;
   onEventClick?: (event: CalendarEvent) => void;
 }
 
-export default function CalendarDay({ day, onSelect, onEventClick }: CalendarDayProps) {
+export default memo(function CalendarDay({ day, onSelectDate, onEventClick }: CalendarDayProps) {
   const dayNumber = day.date.getDate();
   const isCurrentMonth = day.isCurrentMonth;
   const isToday = day.isToday;
   const isSelected = day.isSelected;
   const hasEvents = day.hasEvents;
 
-  const handleDayClick = () => {
+  const handleDayClick = useCallback(() => {
     if (hasEvents && day.events.length > 0 && onEventClick) {
-      // If day has events, show the first event's details
       onEventClick(day.events[0]);
     } else {
-      // Otherwise, just select the day
-      onSelect();
+      onSelectDate(day.date);
     }
-  };
+  }, [hasEvents, day.events, day.date, onEventClick, onSelectDate]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleDayClick();
+    }
+  }, [handleDayClick]);
 
   const baseClasses = `
     h-20 rounded-lg cursor-pointer transition-all duration-200
@@ -45,12 +50,7 @@ export default function CalendarDay({ day, onSelect, onEventClick }: CalendarDay
       role="button"
       tabIndex={0}
       aria-label={`${day.date.toLocaleDateString()}${hasEvents ? `, ${day.events.length} events - click to view details` : ''}`}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          handleDayClick();
-        }
-      }}
+      onKeyDown={handleKeyDown}
     >
       {/* Day number */}
       <div className={`text-sm font-medium mb-1 pl-2 self-start ${hasEvents ? 'text-white' : ''}`}>
@@ -75,4 +75,4 @@ export default function CalendarDay({ day, onSelect, onEventClick }: CalendarDay
 
     </div>
   );
-}
+});

--- a/app/components/calendar/CalendarGrid.tsx
+++ b/app/components/calendar/CalendarGrid.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import { memo } from 'react';
 import { CalendarMonth, CalendarEvent } from '@/types/calendar';
 import { getDayNames } from '@/lib/calendar/utils';
 import CalendarDay from './CalendarDay';
@@ -13,7 +13,7 @@ interface CalendarGridProps {
   isLoading?: boolean;
 }
 
-export default function CalendarGrid({
+export default memo(function CalendarGrid({
   calendarMonth,
   onSelectDate,
   onEventClick,
@@ -71,11 +71,11 @@ export default function CalendarGrid({
           <CalendarDay
             key={`${day.date.getFullYear()}-${day.date.getMonth()}-${day.date.getDate()}-${index}`}
             day={day}
-            onSelect={() => onSelectDate(day.date)}
+            onSelectDate={onSelectDate}
             onEventClick={onEventClick}
           />
         ))}
       </div>
     </div>
   );
-}
+});


### PR DESCRIPTION
Resolves #115 

1. Added `useCallback` on handlers in `CalendarContainer`:
`handleSelectDate`, `handleEventClick`, and `handleCloseModal` are now memoized so their references stay stable across renders.

2. `React.memo` on `CalendarGrid` and `CalendarDay`:
Both components now skip re-rendering when their props haven't changed. So when modal state (`selectedEvent`/`isModalOpen`) updates, the grid doesn't re-render.

3. Eliminated per-cell closures in `CalendarGrid`:
The old code passed `onSelect={() => onSelectDate(day.date)}` to each `CalendarDay`, creating 42 new functions every render. Now it passes `onSelectDate` directly, and `CalendarDay` calls it with `day.date` internally.